### PR TITLE
JCN 224 getter stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `stores` and `hasAccessToAllStores` getters
+- `validateStore`
 
 ## [1.2.1] - 2019-10-16
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ npm install @janiscommerce/api-session
 ## API
 The package exports two classes ApiSession and ApiSessionError.
 
+* validateStore(storeId)
+Validate if the store given is valid for the session.
+Returns *Boolean*.
+
 ### ApiSession
 
 * constructor(authorizationData)
@@ -23,6 +27,8 @@ ApiSession has the following getters:
 * clientId {string} The ID of the client or undefined in case there is no client
 * clientCode {string} The code of the client or undefined in case there is no client
 * profileId {string} The ID of the profile or undefined in case there is no profile
+* stores {array<string>} The List of stores
+* hasAccessToAllStores {boolean} If has access to all stores
 * permissions {array} The permission keys or undefined in case there are no permissions associated
 * *async* client {object} Resolves to the client object with the `getInstance()` method injected. The properties depend on your client internal structure. The client is injected with a `getInstance()` method to propagate the session to other instances.
 
@@ -55,7 +61,9 @@ const session = new ApiSession({
 	permissions: [
 		'catalog:product:read',
 		'catalog:product:write'
-	]
+	],
+	stores: ['store-1'],
+	hasAccessToAllStores: false
 });
 
 console.log(`Session created for user ${session.userId} on client ${session.clientCode}.`);
@@ -68,4 +76,9 @@ const client = await sessionInjectedModel.session.client;
 
 console.log(client);
 // Outputs your client object
+
+const hasAccess = session.validateStore('store-1');
+
+console.log(`Session has access to store 1: ${hasAccess}`);
+// Outputs 'Session has access to store 1: true'
 ```

--- a/lib/api-session.js
+++ b/lib/api-session.js
@@ -169,13 +169,8 @@ class ApiSession {
 	 * @returns {Boolean}
 	 */
 	validateStore(storeId) {
-		if(!storeId || typeof this.hasAccessToAllStores === 'undefined' || !this.stores || !Array.isArray(this.stores))
-			return false;
 
-		if(this.hasAccessToAllStores)
-			return true;
-
-		return !!this.stores.length && this.stores.includes(storeId);
+		return !!this.hasAccessToAllStores || (!!storeId && Array.isArray(this.stores) && this.stores.includes(storeId));
 	}
 }
 

--- a/lib/api-session.js
+++ b/lib/api-session.js
@@ -59,6 +59,24 @@ class ApiSession {
 	}
 
 	/**
+	 * Get the stores array associated to the session
+	 *
+	 * @return {array<string>|undefined} The stores or undefined in case there are no stores associated
+	 */
+	get stores() {
+		return this.authenticationData.stores;
+	}
+
+	/**
+	 * Get the if has Access To All Stores associated to the session
+	 *
+	 * @return {boolean|undefined} The hasAccessToAllStores field or undefined in case there are no hasAccessToAllStores associated
+	 */
+	get hasAccessToAllStores() {
+		return this.authenticationData.hasAccessToAllStores;
+	}
+
+	/**
 	 * Fetch the client data from your own DB
 	 *
 	 * @return {Promise} Resolves to the client object with the `getInstance()` method injected
@@ -143,6 +161,22 @@ class ApiSession {
 		return client;
 	}
 
+
+	/**
+	 * Validate if the session has access to the store
+	 *
+	 * @param {string} storeId Store Id
+	 * @returns {Boolean}
+	 */
+	validateStore(storeId) {
+		if(!storeId || typeof this.hasAccessToAllStores === 'undefined' || !this.stores || !Array.isArray(this.stores))
+			return false;
+
+		if(this.hasAccessToAllStores)
+			return true;
+
+		return !!this.stores.length && this.stores.includes(storeId);
+	}
 }
 
 module.exports = ApiSession;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1866,7 +1866,6 @@
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "requires": {
-            "lru-cache": "^4.0.1",
             "which": "^1.2.9"
           }
         },

--- a/tests/api-session.js
+++ b/tests/api-session.js
@@ -40,6 +40,20 @@ describe('Api Session', () => {
 			it('Should return undefined for client', async () => {
 				assert.strictEqual(await session.client, undefined);
 			});
+
+			it('Should return undefined for stores', async () => {
+				assert.strictEqual(session.stores, undefined);
+			});
+
+			it('Should return undefined for hasAccessToAllStores', async () => {
+				assert.strictEqual(session.hasAccessToAllStores, undefined);
+			});
+		});
+
+		describe('Validate Store', () => {
+			it('Should return false', () => {
+				assert.strictEqual(session.validateStore('store-id'), false);
+			});
 		});
 	});
 
@@ -50,7 +64,9 @@ describe('Api Session', () => {
 			clientId: 'some-client-id',
 			clientCode: 'some-client-code',
 			profileId: 'some-profile-id',
-			permissions: ['service:namespace:method1', 'service:namespace:method2']
+			permissions: ['service:namespace:method1', 'service:namespace:method2'],
+			stores: ['store-1', 'store-2'],
+			hasAccessToAllStores: false
 		});
 
 		describe('Getters', () => {
@@ -72,6 +88,14 @@ describe('Api Session', () => {
 
 			it('Should return the correct permissions', () => {
 				assert.deepStrictEqual(session.permissions, ['service:namespace:method1', 'service:namespace:method2']);
+			});
+
+			it('Should return the correct stores', () => {
+				assert.deepStrictEqual(session.stores, ['store-1', 'store-2']);
+			});
+
+			it('Should return the correct hasAccessToAllStores', () => {
+				assert.strictEqual(session.hasAccessToAllStores, false);
 			});
 
 			it('Should throw if client can\'t be fetched', async () => {
@@ -211,6 +235,96 @@ describe('Api Session', () => {
 				sinon.assert.calledWithExactly(ModelClient.prototype.getByField, 'code', 'some-client-code');
 			});
 		});
-	});
 
+		describe('Validate Store', () => {
+
+			it('Should return false when session has not access to all store and no storeId is passed', () => {
+				assert.strictEqual(session.validateStore(), false);
+			});
+
+			it('Should return false when session has not stores field', () => {
+
+				const invalidSession = new ApiSession({
+					userId: 'some-user-id',
+					clientId: 'some-client-id',
+					clientCode: 'some-client-code',
+					profileId: 'some-profile-id',
+					permissions: ['service:namespace:method1', 'service:namespace:method2'],
+					hasAccessToAllStores: false
+				});
+
+				assert.strictEqual(invalidSession.validateStore('store-1'), false);
+			});
+
+			it('Should return false when session has not valid stores field', () => {
+
+				const invalidSession = new ApiSession({
+					userId: 'some-user-id',
+					clientId: 'some-client-id',
+					clientCode: 'some-client-code',
+					profileId: 'some-profile-id',
+					permissions: ['service:namespace:method1', 'service:namespace:method2'],
+					stores: { 1: 'store-1', 2: 'store-2' },
+					hasAccessToAllStores: false
+				});
+
+				assert.strictEqual(invalidSession.validateStore('store-1'), false);
+			});
+
+			it('Should return false when session has not valid stores field', () => {
+
+				const invalidSession = new ApiSession({
+					userId: 'some-user-id',
+					clientId: 'some-client-id',
+					clientCode: 'some-client-code',
+					profileId: 'some-profile-id',
+					permissions: ['service:namespace:method1', 'service:namespace:method2'],
+					stores: { 1: 'store-1', 2: 'store-2' },
+					hasAccessToAllStores: false
+				});
+
+				assert.strictEqual(invalidSession.validateStore('store-1'), false);
+			});
+
+			it('Should return false when session has an empty array of stores', () => {
+
+				const invalidSession = new ApiSession({
+					userId: 'some-user-id',
+					clientId: 'some-client-id',
+					clientCode: 'some-client-code',
+					profileId: 'some-profile-id',
+					permissions: ['service:namespace:method1', 'service:namespace:method2'],
+					stores: [],
+					hasAccessToAllStores: false
+				});
+
+				assert.strictEqual(invalidSession.validateStore('store-1'), false);
+			});
+
+			it('Should return true when session has access to that store', () => {
+				assert.strictEqual(session.validateStore('store-1'), true);
+				assert.strictEqual(session.validateStore('store-2'), true);
+			});
+
+			it('Should return false when session has no access to that store', () => {
+				assert.strictEqual(session.validateStore('store-0'), false);
+				assert.strictEqual(session.validateStore('store-3'), false);
+			});
+
+			it('Should return true when session has access to all stores', () => {
+
+				const invalidSession = new ApiSession({
+					userId: 'some-user-id',
+					clientId: 'some-client-id',
+					clientCode: 'some-client-code',
+					profileId: 'some-profile-id',
+					permissions: ['service:namespace:method1', 'service:namespace:method2'],
+					stores: [],
+					hasAccessToAllStores: true
+				});
+
+				assert.strictEqual(invalidSession.validateStore('store-1'), true);
+			});
+		});
+	});
 });


### PR DESCRIPTION
**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-224
​
**DESCRIPCIÓN DEL REQUERIMIENTO**
Se requiere modificar el package @janiscommerce/api-session para soportar los nuevos campos de stores. Las modificaciones son las siguientes.

* Agregar un getter no-estático stores para devolver `authenticationData.stores`

* Agregar un getter no-estático `hasAccessToAllStores` para devolver `authenticationData.hasAccessToAllStores`

* Agregar un método `validateStore(storeId)` para validar que el usuario (o servicio) tenga permiso para la tienda.

El método debe devolver true cuando se cumpla alguna de las siguientes condiciones:

* El dato `authenticationData.hasAccessToAllStores` exista y sea idéntico a true

* El dato `authenticationData.stores` exista, sea un array e incluya al id de la tienda recibido en el parámetro storeId.

* El método debe devolver false cuando no se cumpla ninguna de las condiciones anteriores.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollaron los requerimientos solicitados