### PR TITLE
Jcn 291 location support to api session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+### Added
+- `locations` and `hasAccessToAllLocations` getters
+- `validateLocation`
+
+### Removed
+- - `stores` and `hasAccessToAllStores` getters
+- `validateStore`
+
 ## [1.4.0] - 2020-05-19
 ### Removed
 - `package-lock.json` file

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ApiSession has the following getters:
 * *async* client {object} Resolves to the client object with the `getInstance()` method injected. The properties depend on your client internal structure. The client is injected with a `getInstance()` method to propagate the session to other instances.
 
 
-:warning::skull: Since version 2.0.0 stores and hasAccessToAllStores getters have been removed . Also the method validateStore(storeId). :skull::warning:
+:warning::skull: Since version 2.0.0 stores and hasAccessToAllStores getters have been removed . Also the method validateStore(storeId). Now it supports locations with  locations and hasAccesToAllLocations getters and also the method validateLocation(locationId) :skull::warning:
 
 ## Settings
 The package has some configurable parameters, which are loaded using [@janiscommerce/settings](https://www.npmjs.com/package/@janiscommerce/settings)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ApiSession has the following getters:
 * *async* client {object} Resolves to the client object with the `getInstance()` method injected. The properties depend on your client internal structure. The client is injected with a `getInstance()` method to propagate the session to other instances.
 
 
-:warning::skull: Since version 2.0.0 stores and hasAccesToAllStores getters have been removed . Also the method validateStore(storeId). :skull::warning:
+:warning::skull: Since version 2.0.0 stores and hasAccessToAllStores getters have been removed . Also the method validateStore(storeId). :skull::warning:
 
 ## Settings
 The package has some configurable parameters, which are loaded using [@janiscommerce/settings](https://www.npmjs.com/package/@janiscommerce/settings)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ApiSession has the following getters:
 * *async* client {object} Resolves to the client object with the `getInstance()` method injected. The properties depend on your client internal structure. The client is injected with a `getInstance()` method to propagate the session to other instances.
 
 
-:warning::skull: Since version 2.0.0 stores and hasAccessToAllStores getters have been removed . Also the method validateStore(storeId). Now it supports locations with  locations and hasAccesToAllLocations getters and also the method validateLocation(locationId) :skull::warning:
+:warning::skull: Since version 2.0.0 stores and hasAccessToAllStores getters have been removed . Also the method validateStore(storeId). Now it supports locations with  locations and hasAccessToAllLocations getters and also the method validateLocation(locationId) :skull::warning:
 
 ## Settings
 The package has some configurable parameters, which are loaded using [@janiscommerce/settings](https://www.npmjs.com/package/@janiscommerce/settings)

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ npm install @janiscommerce/api-session
 ## API
 The package exports two classes ApiSession and ApiSessionError.
 
-* validateStore(storeId)
-Validate if the store given is valid for the session.
-Returns *Boolean*.
-
 ### ApiSession
 
 * constructor(authorizationData)
 Receives an object with the following (optional) properties: { userId, clientId, clientCode, profileId, permissions }
+
+* validateLocation(locationId)
+Validate if the location given is valid for the session.
+Returns *Boolean*.
 
 ApiSession has the following getters:
 * userId {string} The ID of the user or undefined in case there is no user
@@ -30,10 +30,13 @@ ApiSession has the following getters:
 * clientId {string} The ID of the client or undefined in case there is no client
 * clientCode {string} The code of the client or undefined in case there is no client
 * profileId {string} The ID of the profile or undefined in case there is no profile
-* stores {array<string>} The List of stores
-* hasAccessToAllStores {boolean} If has access to all stores
+* locations {array<string>} The List of locations
+* hasAccessToAllLocations {boolean} If has access to all locations
 * permissions {array} The permission keys or undefined in case there are no permissions associated
 * *async* client {object} Resolves to the client object with the `getInstance()` method injected. The properties depend on your client internal structure. The client is injected with a `getInstance()` method to propagate the session to other instances.
+
+
+:warning::skull: Since version 2.0.0 stores and hasAccesToAllStores getters have been removed . Also the method validateStore(storeId). :skull::warning:
 
 ## Settings
 The package has some configurable parameters, which are loaded using [@janiscommerce/settings](https://www.npmjs.com/package/@janiscommerce/settings)
@@ -66,8 +69,8 @@ const session = new ApiSession({
 		'catalog:product:read',
 		'catalog:product:write'
 	],
-	stores: ['store-1'],
-	hasAccessToAllStores: false
+	locations: ['location-1'],
+	hasAccessToAllLocations: false
 });
 
 console.log(`Session created for user ${session.userId} on client ${session.clientCode}.`);
@@ -81,8 +84,8 @@ const client = await sessionInjectedModel.session.client;
 console.log(client);
 // Outputs your client object
 
-const hasAccess = session.validateStore('store-1');
+const hasAccess = session.validateLocation('location-1');
 
-console.log(`Session has access to store 1: ${hasAccess}`);
-// Outputs 'Session has access to store 1: true'
+console.log(`Session has access to location 1: ${hasAccess}`);
+// Outputs 'Session has access to location 1: true'
 ```

--- a/lib/api-session.js
+++ b/lib/api-session.js
@@ -87,21 +87,21 @@ class ApiSession {
 	}
 
 	/**
-	 * Get the stores array associated to the session
+	 * Get the locations array associated to the session
 	 *
-	 * @return {array<string>|undefined} The stores or undefined in case there are no stores associated
+	 * @return {array<string>|undefined} The locations or undefined in case there are no locations associated
 	 */
-	get stores() {
-		return this.authenticationData.stores;
+	get locations() {
+		return this.authenticationData.locations;
 	}
 
 	/**
-	 * Get the if has Access To All Stores associated to the session
+	 * Get the if has Access To All locations associated to the session
 	 *
-	 * @return {boolean|undefined} The hasAccessToAllStores field or undefined in case there are no hasAccessToAllStores associated
+	 * @return {boolean|undefined} The hasAccessToAllLocations field or undefined in case there are no hasAccessToAllLocations associated
 	 */
-	get hasAccessToAllStores() {
-		return this.authenticationData.hasAccessToAllStores;
+	get hasAccessToAllLocations() {
+		return this.authenticationData.hasAccessToAllLocations;
 	}
 
 	/**
@@ -191,13 +191,13 @@ class ApiSession {
 
 
 	/**
-	 * Validate if the session has access to the store
+	 * Validate if the session has access to the location
 	 *
-	 * @param {string} storeId Store Id
+	 * @param {string} locationId Location Id
 	 * @returns {Boolean}
 	 */
-	validateStore(storeId) {
-		return !!this.hasAccessToAllStores || (!!storeId && Array.isArray(this.stores) && this.stores.includes(storeId));
+	validateLocation(locationId) {
+		return !!this.hasAccessToAllLocations || (!!locationId && Array.isArray(this.locations) && this.locations.includes(locationId));
 	}
 }
 

--- a/tests/api-session.js
+++ b/tests/api-session.js
@@ -41,12 +41,12 @@ describe('Api Session', () => {
 				assert.strictEqual(await session.client, undefined);
 			});
 
-			it('Should return undefined for stores', async () => {
-				assert.strictEqual(session.stores, undefined);
+			it('Should return undefined for locations', async () => {
+				assert.strictEqual(session.locations, undefined);
 			});
 
-			it('Should return undefined for hasAccessToAllStores', async () => {
-				assert.strictEqual(session.hasAccessToAllStores, undefined);
+			it('Should return undefined for hasAccessToAllLocations', async () => {
+				assert.strictEqual(session.hasAccessToAllLocations, undefined);
 			});
 
 			it('Should return false for userIsDev', () => {
@@ -62,9 +62,9 @@ describe('Api Session', () => {
 			});
 		});
 
-		describe('Validate Store', () => {
+		describe('Validate Locations', () => {
 			it('Should return false', () => {
-				assert.strictEqual(session.validateStore('store-id'), false);
+				assert.strictEqual(session.validateLocation('locations-id'), false);
 			});
 		});
 	});
@@ -79,8 +79,8 @@ describe('Api Session', () => {
 			clientCode: 'some-client-code',
 			profileId: 'some-profile-id',
 			permissions: ['service:namespace:method1', 'service:namespace:method2'],
-			stores: ['store-1', 'store-2'],
-			hasAccessToAllStores: false
+			locations: ['location-1', 'location-2'],
+			hasAccessToAllLocations: false
 		});
 
 		describe('Getters', () => {
@@ -116,12 +116,12 @@ describe('Api Session', () => {
 				assert.deepStrictEqual(session.permissions, ['service:namespace:method1', 'service:namespace:method2']);
 			});
 
-			it('Should return the correct stores', () => {
-				assert.deepStrictEqual(session.stores, ['store-1', 'store-2']);
+			it('Should return the correct locations', () => {
+				assert.deepStrictEqual(session.locations, ['location-1', 'location-2']);
 			});
 
-			it('Should return the correct hasAccessToAllStores', () => {
-				assert.strictEqual(session.hasAccessToAllStores, false);
+			it('Should return the correct hasAccessToAllLocations', () => {
+				assert.strictEqual(session.hasAccessToAllLocations, false);
 			});
 
 			it('Should throw if client can\'t be fetched', async () => {
@@ -262,13 +262,13 @@ describe('Api Session', () => {
 			});
 		});
 
-		describe('Validate Store', () => {
+		describe('Validate location', () => {
 
-			it('Should return false when session has not access to all store and no storeId is passed', () => {
-				assert.strictEqual(session.validateStore(), false);
+			it('Should return false when session has not access to all location and no locationId is passed', () => {
+				assert.strictEqual(session.validateLocation(), false);
 			});
 
-			it('Should return false when session has not stores field', () => {
+			it('Should return false when session has not locations field', () => {
 
 				const invalidSession = new ApiSession({
 					userId: 'some-user-id',
@@ -276,13 +276,13 @@ describe('Api Session', () => {
 					clientCode: 'some-client-code',
 					profileId: 'some-profile-id',
 					permissions: ['service:namespace:method1', 'service:namespace:method2'],
-					hasAccessToAllStores: false
+					hasAccessToAlllocations: false
 				});
 
-				assert.strictEqual(invalidSession.validateStore('store-1'), false);
+				assert.strictEqual(invalidSession.validateLocation('location-1'), false);
 			});
 
-			it('Should return false when session has not valid stores field', () => {
+			it('Should return false when session has not valid locations field', () => {
 
 				const invalidSession = new ApiSession({
 					userId: 'some-user-id',
@@ -290,14 +290,14 @@ describe('Api Session', () => {
 					clientCode: 'some-client-code',
 					profileId: 'some-profile-id',
 					permissions: ['service:namespace:method1', 'service:namespace:method2'],
-					stores: { 1: 'store-1', 2: 'store-2' },
-					hasAccessToAllStores: false
+					locations: { 1: 'location-1', 2: 'location-2' },
+					hasAccessToAllLocations: false
 				});
 
-				assert.strictEqual(invalidSession.validateStore('store-1'), false);
+				assert.strictEqual(invalidSession.validateLocation('location-1'), false);
 			});
 
-			it('Should return false when session has not valid stores field', () => {
+			it('Should return false when session has not valid locations field', () => {
 
 				const invalidSession = new ApiSession({
 					userId: 'some-user-id',
@@ -305,14 +305,14 @@ describe('Api Session', () => {
 					clientCode: 'some-client-code',
 					profileId: 'some-profile-id',
 					permissions: ['service:namespace:method1', 'service:namespace:method2'],
-					stores: { 1: 'store-1', 2: 'store-2' },
-					hasAccessToAllStores: false
+					locations: { 1: 'location-1', 2: 'location-2' },
+					hasAccessToAllLocations: false
 				});
 
-				assert.strictEqual(invalidSession.validateStore('store-1'), false);
+				assert.strictEqual(invalidSession.validateLocation('location-1'), false);
 			});
 
-			it('Should return false when session has an empty array of stores', () => {
+			it('Should return false when session has an empty array of locations', () => {
 
 				const invalidSession = new ApiSession({
 					userId: 'some-user-id',
@@ -320,24 +320,24 @@ describe('Api Session', () => {
 					clientCode: 'some-client-code',
 					profileId: 'some-profile-id',
 					permissions: ['service:namespace:method1', 'service:namespace:method2'],
-					stores: [],
-					hasAccessToAllStores: false
+					locations: [],
+					hasAccessToAllLocations: false
 				});
 
-				assert.strictEqual(invalidSession.validateStore('store-1'), false);
+				assert.strictEqual(invalidSession.validateLocation('location-1'), false);
 			});
 
-			it('Should return true when session has access to that store', () => {
-				assert.strictEqual(session.validateStore('store-1'), true);
-				assert.strictEqual(session.validateStore('store-2'), true);
+			it('Should return true when session has access to that location', () => {
+				assert.strictEqual(session.validateLocation('location-1'), true);
+				assert.strictEqual(session.validateLocation('location-2'), true);
 			});
 
-			it('Should return false when session has no access to that store', () => {
-				assert.strictEqual(session.validateStore('store-0'), false);
-				assert.strictEqual(session.validateStore('store-3'), false);
+			it('Should return false when session has no access to that location', () => {
+				assert.strictEqual(session.validateLocation('location-0'), false);
+				assert.strictEqual(session.validateLocation('location-3'), false);
 			});
 
-			it('Should return true when session has access to all stores', () => {
+			it('Should return true when session has access to all locations', () => {
 
 				const invalidSession = new ApiSession({
 					userId: 'some-user-id',
@@ -345,11 +345,11 @@ describe('Api Session', () => {
 					clientCode: 'some-client-code',
 					profileId: 'some-profile-id',
 					permissions: ['service:namespace:method1', 'service:namespace:method2'],
-					stores: [],
-					hasAccessToAllStores: true
+					locations: [],
+					hasAccessToAllLocations: true
 				});
 
-				assert.strictEqual(invalidSession.validateStore('store-1'), true);
+				assert.strictEqual(invalidSession.validateLocation('location-1'), true);
 			});
 		});
 	});


### PR DESCRIPTION
**Link al ticket**
https://fizzmod.atlassian.net/browse/JCN-291
**Descripción del requerimiento**
Se require dar soporte a las locations provistas por JID. Eliminar todo lo relacionado con stores.
**Descripción de la solución**
Se modificó: 
- El getter `stores` por `locations`
- El getter `hasAccessToAllStores` por `hasAccesToAllLocations`
- El método `validateStore` por `validateLocation`. 
Se modificaron los test de igual modo. 